### PR TITLE
Updated css so the article photos wouldn't clip

### DIFF
--- a/chrissmit/static/css/site.css
+++ b/chrissmit/static/css/site.css
@@ -210,7 +210,7 @@ a:hover {
 .card-img-top {
     width: auto;
     height: var(--cardPic);
-    object-fit: cover;
+    object-fit: contain;
 }
 
 .tag-bucket {


### PR DESCRIPTION
Changed the pic in the pane on the all articles pages so it fits to the dimension without clipping.